### PR TITLE
Programme render now uses JetBrains Mono as its default font

### DIFF
--- a/src/components/ProgrammeRender.tsx
+++ b/src/components/ProgrammeRender.tsx
@@ -41,7 +41,7 @@ function ProgrammeRender({
 
   return (
     <Box maxHeight="100vh" overflow="scroll">
-      <RawHtml rawHtml={htmlString} />
+      <RawHtml rawHtml={htmlString} style={{ fontFamily: "Jetbrains Mono" }} />
     </Box>
   );
 }

--- a/src/components/RawHtml.tsx
+++ b/src/components/RawHtml.tsx
@@ -1,7 +1,9 @@
 import DomPurify from "dompurify";
+import { CSSProperties } from "react";
 
 interface RawHtmlProps {
   rawHtml: string;
+  style?: CSSProperties | undefined;
 }
 
 /**
@@ -11,11 +13,18 @@ interface RawHtmlProps {
  *
  * @param rawHtml - Any valid HTML document as a string.
  *
+ * @param style - A CSS object containing styles for the HTML compoent.
+ *
  * @returns A React element used to render `rawHtml`.
  */
-function RawHtml({ rawHtml }: RawHtmlProps): React.ReactElement {
+function RawHtml({ rawHtml, style }: RawHtmlProps): React.ReactElement {
   const sanitizedHtml = DomPurify.sanitize(rawHtml);
-  return <div dangerouslySetInnerHTML={{ __html: sanitizedHtml }}></div>;
+  return (
+    <div
+      dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
+      style={style}
+    ></div>
+  );
 }
 
 export default RawHtml;


### PR DESCRIPTION
This fixes the issue where elements of the render which do not specifically overwrite their font would use the page default font instead of JetBrains Mono