### PR TITLE
Fix: Using a relative URL for fetching stylesheet when printing render

### DIFF
--- a/src/logic/pdfExport.ts
+++ b/src/logic/pdfExport.ts
@@ -11,7 +11,7 @@ function createIframe(): HTMLIFrameElement {
 }
 
 async function templateDocument(): Promise<string> {
-  const css = await (await fetch("/swiML.css")).text();
+  const css = await (await fetch("./swiML.css")).text();
 
   return `\
     <!doctype html>


### PR DESCRIPTION
The previous URL caused the fetch for the CSS to return a GitHub Pages 404 page instead of the stylesheet.