### PR TITLE
Fix: Using relative URLs for fonts in CSS

### DIFF
--- a/public/swiML.css
+++ b/public/swiML.css
@@ -240,9 +240,9 @@ https://github.com/bartneck/swiML/raw/main/fonts/JetBrainsMono/fonts/webfonts/Je
 @font-face {
   font-family: "JetBrains Mono ExtraBold";
   src:
-    url("/fonts/JetBrainsMono/fonts/webfonts/JetBrainsMono-ExtraBold.woff2")
+    url("./fonts/JetBrainsMono/fonts/webfonts/JetBrainsMono-ExtraBold.woff2")
       format("woff2"),
-    url("/fonts/JetBrainsMono/fonts/ttf/JetBrainsMono-ExtraBold.ttf")
+    url("./fonts/JetBrainsMono/fonts/ttf/JetBrainsMono-ExtraBold.ttf")
       format("truetype");
   font-weight: 800;
   font-style: normal;
@@ -252,9 +252,9 @@ https://github.com/bartneck/swiML/raw/main/fonts/JetBrainsMono/fonts/webfonts/Je
 @font-face {
   font-family: "JetBrains Mono";
   src:
-    url("/fonts/JetBrainsMono/fonts/webfonts/JetBrainsMono-Regular.woff2")
+    url("./fonts/JetBrainsMono/fonts/webfonts/JetBrainsMono-Regular.woff2")
       format("woff2"),
-    url("/fonts/JetBrainsMono/fonts/ttf/JetBrainsMono-Regular.ttf")
+    url("./fonts/JetBrainsMono/fonts/ttf/JetBrainsMono-Regular.ttf")
       format("truetype");
   font-weight: 400;
   font-style: normal;
@@ -264,9 +264,9 @@ https://github.com/bartneck/swiML/raw/main/fonts/JetBrainsMono/fonts/webfonts/Je
 @font-face {
   font-family: "JetBrains Mono Italic";
   src:
-    url("/fonts/JetBrainsMono/fonts/webfonts/JetBrainsMono-Italic.woff2")
+    url("./fonts/JetBrainsMono/fonts/webfonts/JetBrainsMono-Italic.woff2")
       format("woff2"),
-    url("/fonts/JetBrainsMono/fonts/ttf/JetBrainsMono-Italic.ttf")
+    url("./fonts/JetBrainsMono/fonts/ttf/JetBrainsMono-Italic.ttf")
       format("truetype");
   font-weight: 400;
   font-style: italic;
@@ -276,9 +276,9 @@ https://github.com/bartneck/swiML/raw/main/fonts/JetBrainsMono/fonts/webfonts/Je
 @font-face {
   font-family: "JetBrains Mono Thin";
   src:
-    url("/fonts/JetBrainsMono/fonts/webfonts/JetBrainsMono-Thin.woff2")
+    url("./fonts/JetBrainsMono/fonts/webfonts/JetBrainsMono-Thin.woff2")
       format("woff2"),
-    url("/fonts/JetBrainsMono/fonts/ttf/JetBrainsMono-Thin.ttf")
+    url("./fonts/JetBrainsMono/fonts/ttf/JetBrainsMono-Thin.ttf")
       format("truetype");
   font-weight: 100;
   font-style: normal;
@@ -288,9 +288,9 @@ https://github.com/bartneck/swiML/raw/main/fonts/JetBrainsMono/fonts/webfonts/Je
 @font-face {
   font-family: "JetBrains Mono SemiBold";
   src:
-    url("/fonts/JetBrainsMono/fonts/webfonts/JetBrainsMono-SemiBold.woff2")
+    url("./fonts/JetBrainsMono/fonts/webfonts/JetBrainsMono-SemiBold.woff2")
       format("woff2"),
-    url("/fonts/JetBrainsMono/fonts/ttf/JetBrainsMono-SemiBold.ttf")
+    url("./fonts/JetBrainsMono/fonts/ttf/JetBrainsMono-SemiBold.ttf")
       format("truetype");
   font-weight: 600;
   font-style: normal;


### PR DESCRIPTION
Printing the programme render to a PDF worked perfectly fine when running locally, but the fonts did not show up when printing on the deployed instance. These relative urls should fix this problem.