### PR TITLE
Fix: removed now incorrect 'Generate SEF JSON' step from deploy workflow

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -38,10 +38,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Generate SEF JSON
-        run: |
-          ./scripts/generateSef.bash https://bartneck.github.io/SwimDsl
-
       - name: Build project
         run: npm run build
 


### PR DESCRIPTION
The referenced bash script was deleted with #34 and its functionality now occurs automatically with npm prepare hook.