### PR TITLE
Fix side panel editor overflow within the viewport

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -93,9 +93,15 @@ function App(): React.ReactElement {
             setPanelPage={setPanelPage}
           />
         </NavBar>
-        <Box sx={{ display: "flex", flex: 1, overflow: "hidden" }}>
+        <Box
+          sx={{ display: "flex", flex: 1, overflow: "hidden", minHeight: 0 }}
+        >
           <Box
-            sx={{ width: panelPage !== null ? "50%" : "100%" }}
+            sx={{
+              width: panelPage !== null ? "50%" : "100%",
+              minWidth: 0,
+              minHeight: 0,
+            }}
             borderRight="1px solid"
           >
             <CodeMirror
@@ -109,7 +115,14 @@ function App(): React.ReactElement {
             />
           </Box>
           {panelPage !== null && (
-            <Box sx={{ width: "50%", overflow: "auto" }}>
+            <Box
+              sx={{
+                width: "50%",
+                overflow: "hidden",
+                minWidth: 0,
+                minHeight: 0,
+              }}
+            >
               {showPanel(panelPage)}
             </Box>
           )}

--- a/src/components/SwimlDisplay.tsx
+++ b/src/components/SwimlDisplay.tsx
@@ -15,12 +15,14 @@ interface SwimlDisplayProps {
  */
 function SwimlDisplay({ xmlContent }: SwimlDisplayProps): React.ReactElement {
   const theme = useTheme();
+
   return (
     <CodeMirror
       readOnly
       value={xmlContent}
-      height={`calc(100vh - ${theme.mixins.toolbar.minHeight}px)`}
+      height="100%"
       width="100%"
+      style={{ height: "100%" }}
       theme={theme.palette.mode}
       extensions={[xml()]}
     />

--- a/src/components/TutorialPane.tsx
+++ b/src/components/TutorialPane.tsx
@@ -15,14 +15,14 @@ import { example_programme } from "../example_programme";
  */
 function TutorialPane(): React.ReactElement {
   const [value, setValue] = React.useState(example_programme);
-
   const theme = useTheme();
 
   return (
     <CodeMirror
       value={value}
-      height={`calc(100vh - ${theme.mixins.toolbar.minHeight}px)`}
+      height="100%"
       width="100%"
+      style={{ height: "100%" }}
       theme={theme.palette.mode}
       extensions={[swimdsl()]}
       onChange={(textContent: string) => {


### PR DESCRIPTION
This fixes a layout issue where the tutorial and generated XML panels could overflow their container and show an extra scrollbar. The overflow came from sizing those editors against 100vh instead of the height provided by the app’s existing flex layout.

Changes:

- Make the main editor/panel split layout opt into proper flex shrinking with minHeight: 0 and minWidth: 0
- Stop the tutorial and XML side-panel editors from calculating their own viewport height
- Size those CodeMirror instances to 100% of their parent container instead

Result:

- The extra scrollbar inside the side panel is removed
- The tutorial and XML panel horizontal scrollbars are fully visible again
- The panel content now stays aligned with the viewport height more reliably across screen sizes