### PR TITLE
Polish header and right-panel state controls

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,5 +1,7 @@
 import AddIcon from "@mui/icons-material/Add";
 import CodeIcon from "@mui/icons-material/Code";
+import FolderOpenRoundedIcon from "@mui/icons-material/FolderOpenRounded";
+import KeyboardArrowDownRoundedIcon from "@mui/icons-material/KeyboardArrowDownRounded";
 import PictureAsPdfIcon from "@mui/icons-material/PictureAsPdf";
 import SaveAsIcon from "@mui/icons-material/SaveAs";
 import UploadFileIcon from "@mui/icons-material/UploadFile";
@@ -10,9 +12,9 @@ import ListItemIcon from "@mui/material/ListItemIcon";
 import ListItemText from "@mui/material/ListItemText";
 import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
-import Paper from "@mui/material/Paper";
 import Toolbar from "@mui/material/Toolbar";
 import Typography from "@mui/material/Typography";
+import { alpha } from "@mui/material/styles";
 import React from "react";
 
 import {
@@ -36,6 +38,39 @@ interface NavBarProps {
   htmlString: string;
   renderNode: React.RefObject<HTMLIFrameElement | null>;
   children?: React.ReactNode;
+}
+
+function SwimDslLogo(): React.ReactElement {
+  return (
+    <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, minWidth: 0 }}>
+      <Box sx={{ minWidth: 0 }}>
+        <Typography
+          component="div"
+          sx={{
+            color: "rgba(255, 255, 255, 0.7)",
+            fontSize: "0.68rem",
+            fontWeight: 700,
+            letterSpacing: "0.26em",
+            textTransform: "uppercase",
+          }}
+        >
+          Swim Programme Editor
+        </Typography>
+        <Typography
+          component="div"
+          sx={{
+            color: "#ffffff",
+            fontSize: { xs: "1.2rem", sm: "1.45rem" },
+            fontWeight: 800,
+            letterSpacing: "-0.05em",
+            lineHeight: 1,
+          }}
+        >
+          SwimDSL
+        </Typography>
+      </Box>
+    </Box>
+  );
 }
 
 /**
@@ -71,6 +106,11 @@ function NavBar({
 
   function newProgramme() {
     window.open("./", "_blank")?.focus();
+  }
+
+  function runFileAction(action: () => void | Promise<void>) {
+    closeFileMenu();
+    void action();
   }
 
   const fileMenuOptions: FileMenuItem[] = [
@@ -120,30 +160,108 @@ function NavBar({
 
   return (
     <AppBar
-      sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}
+      elevation={0}
+      sx={{
+        zIndex: (theme) => theme.zIndex.drawer + 1,
+        borderBottom: "1px solid rgba(255, 255, 255, 0.12)",
+        background:
+          "linear-gradient(135deg, #082f49 0%, #0f4c81 38%, #1d4ed8 100%)",
+        boxShadow: "0 20px 45px rgba(15, 23, 42, 0.2)",
+      }}
       position="static"
     >
-      <Toolbar>
-        <Paper sx={{ paddingX: "1em" }}>
-          <Typography variant="h6" component="div">
-            SwimDSL
-          </Typography>
-        </Paper>
+      <Toolbar
+        sx={{
+          gap: 1.5,
+          py: 1.25,
+          alignItems: "center",
+          flexWrap: "wrap",
+        }}
+      >
+        <SwimDslLogo />
 
-        <Button id="basic-button" onClick={openFileMenu} color="inherit">
+        <Button
+          id="file-menu-button"
+          onClick={openFileMenu}
+          color="inherit"
+          variant="contained"
+          startIcon={<FolderOpenRoundedIcon />}
+          endIcon={
+            <KeyboardArrowDownRoundedIcon
+              sx={{
+                transform: open ? "rotate(180deg)" : "rotate(0deg)",
+                transition: "transform 0.2s ease",
+              }}
+            />
+          }
+          aria-controls={open ? "file-menu" : undefined}
+          aria-expanded={open ? "true" : undefined}
+          aria-haspopup="menu"
+          sx={{
+            px: 2,
+            py: 1,
+            borderRadius: 999,
+            textTransform: "none",
+            fontWeight: 700,
+            backgroundColor: alpha("#ffffff", open ? 0.3 : 0.18),
+            boxShadow: "0 12px 24px rgba(8, 47, 73, 0.24)",
+            border: "1px solid rgba(255, 255, 255, 0.22)",
+            "&:hover": {
+              backgroundColor: alpha("#ffffff", 0.28),
+              boxShadow: "0 16px 28px rgba(8, 47, 73, 0.26)",
+            },
+          }}
+        >
           File
         </Button>
 
-        <Menu open={open} anchorEl={anchorEl} onClose={closeFileMenu}>
+        <Menu
+          id="file-menu"
+          open={open}
+          anchorEl={anchorEl}
+          onClose={closeFileMenu}
+          anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+          transformOrigin={{ vertical: "top", horizontal: "left" }}
+          slotProps={{
+            list: {
+              "aria-labelledby": "file-menu-button",
+            },
+            paper: {
+              elevation: 0,
+              sx: {
+                mt: 1,
+                minWidth: 220,
+                borderRadius: 3,
+                border: "1px solid",
+                borderColor: "divider",
+                boxShadow: "0 20px 50px rgba(15, 23, 42, 0.18)",
+              },
+            },
+          }}
+        >
           {fileMenuOptions.map(({ text, icon, onclick }, index) => (
-            <MenuItem onClick={onclick} key={index}>
+            <MenuItem
+              onClick={() => {
+                runFileAction(onclick);
+              }}
+              key={index}
+            >
               <ListItemIcon>{icon}</ListItemIcon>
               <ListItemText>{text}</ListItemText>
             </MenuItem>
           ))}
         </Menu>
 
-        <Box sx={{ ml: "auto" }}>{children}</Box>
+        <Box
+          sx={{
+            ml: { md: "auto" },
+            display: "flex",
+            width: { xs: "100%", md: "auto" },
+            justifyContent: { xs: "center", md: "flex-end" },
+          }}
+        >
+          {children}
+        </Box>
       </Toolbar>
     </AppBar>
   );

--- a/src/components/SidePanelSwitcher.tsx
+++ b/src/components/SidePanelSwitcher.tsx
@@ -1,10 +1,12 @@
-import CodeIcon from "@mui/icons-material/Code";
-import HelpIcon from "@mui/icons-material/Help";
-import ImageIcon from "@mui/icons-material/Image";
-import VisibilityOffIcon from "@mui/icons-material/VisibilityOff";
+import CodeRoundedIcon from "@mui/icons-material/CodeRounded";
+import HelpOutlineRoundedIcon from "@mui/icons-material/HelpOutlineRounded";
+import ImageRoundedIcon from "@mui/icons-material/ImageRounded";
+import VisibilityOffRoundedIcon from "@mui/icons-material/VisibilityOffRounded";
+import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Paper from "@mui/material/Paper";
 import Tooltip from "@mui/material/Tooltip";
+import Typography from "@mui/material/Typography";
 import React from "react";
 
 import PanelPage from "../types/PanelPage";
@@ -13,28 +15,40 @@ interface SidePanelItem {
   page: PanelPage | null;
   icon: React.ReactElement;
   label: string;
+  status: string;
+  tooltip: string;
 }
 
+const hiddenPanelItem: SidePanelItem = {
+  page: null,
+  icon: <VisibilityOffRoundedIcon />,
+  label: "Hide",
+  status: "Hidden",
+  tooltip: "Hide right panel",
+};
+
 const sideBarItems: SidePanelItem[] = [
-  {
-    page: null,
-    icon: <VisibilityOffIcon />,
-    label: "Hide panel",
-  },
+  hiddenPanelItem,
   {
     page: PanelPage.RENDER,
-    icon: <ImageIcon />,
-    label: "Show render",
+    icon: <ImageRoundedIcon />,
+    label: "Preview",
+    status: "Render preview",
+    tooltip: "Show rendered preview",
   },
   {
     page: PanelPage.TUTORIAL,
-    icon: <HelpIcon />,
-    label: "Show tutorial",
+    icon: <HelpOutlineRoundedIcon />,
+    label: "Guide",
+    status: "Tutorial guide",
+    tooltip: "Show tutorial guide",
   },
   {
     page: PanelPage.SWIML_XML,
-    icon: <CodeIcon />,
-    label: "Show swiML XML",
+    icon: <CodeRoundedIcon />,
+    label: "XML",
+    status: "swiML XML",
+    tooltip: "Show generated swiML XML",
   },
 ];
 
@@ -57,23 +71,101 @@ function SidePaneSwitcher({
   setPanelPage,
   activePanelPage,
 }: SidePaneSwitcherProps): React.ReactElement {
+  const activePanelItem =
+    sideBarItems.find(({ page }) => page === activePanelPage) ?? hiddenPanelItem;
+
   return (
-    <Paper>
-      {sideBarItems.map(({ icon, page, label }, index) => (
-        <Tooltip title={label} key={index}>
-          <span>
-            <Button
-              onClick={() => {
-                setPanelPage(page);
-              }}
-              disabled={activePanelPage === page}
-              color="inherit"
-            >
-              {icon}
-            </Button>
-          </span>
-        </Tooltip>
-      ))}
+    <Paper
+      elevation={0}
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        gap: 1,
+        flexWrap: "wrap",
+        justifyContent: "flex-end",
+        px: 1,
+        py: 0.75,
+        borderRadius: 3,
+        backgroundColor: "rgba(255, 255, 255, 0.08)",
+        border: "1px solid rgba(255, 255, 255, 0.16)",
+        backdropFilter: "blur(12px)",
+      }}
+    >
+      <Box sx={{ px: 1, minWidth: 0 }}>
+        <Typography
+          variant="caption"
+          sx={{
+            display: "block",
+            color: "rgba(255, 255, 255, 0.72)",
+            fontWeight: 700,
+            letterSpacing: "0.1em",
+            textTransform: "uppercase",
+          }}
+        >
+          Right panel
+        </Typography>
+        <Typography
+          variant="body2"
+          sx={{ color: "#ffffff", fontWeight: 700, lineHeight: 1.2 }}
+        >
+          {activePanelItem.status}
+        </Typography>
+      </Box>
+
+      <Box
+        sx={{
+          display: "flex",
+          gap: 0.75,
+          flexWrap: "wrap",
+          justifyContent: "flex-end",
+        }}
+      >
+        {sideBarItems.map(({ icon, page, label, tooltip }) => {
+          const selected = activePanelPage === page;
+
+          return (
+            <Tooltip title={tooltip} key={label}>
+              <Button
+                onClick={() => {
+                  setPanelPage(page);
+                }}
+                color="inherit"
+                variant={selected ? "contained" : "text"}
+                startIcon={icon}
+                aria-pressed={selected}
+                sx={{
+                  minWidth: 0,
+                  px: 1.5,
+                  py: 0.8,
+                  borderRadius: 999,
+                  textTransform: "none",
+                  fontWeight: 700,
+                  lineHeight: 1,
+                  border: "1px solid",
+                  borderColor: selected
+                    ? "rgba(255, 255, 255, 0.92)"
+                    : "rgba(255, 255, 255, 0.14)",
+                  backgroundColor: selected
+                    ? "#ffffff"
+                    : "rgba(255, 255, 255, 0.04)",
+                  color: selected ? "#0f172a" : "#ffffff",
+                  boxShadow: selected
+                    ? "0 12px 24px rgba(15, 23, 42, 0.18)"
+                    : "none",
+                  "&:hover": {
+                    backgroundColor: selected
+                      ? "#ffffff"
+                      : "rgba(255, 255, 255, 0.14)",
+                    borderColor: "rgba(255, 255, 255, 0.28)",
+                  },
+                }}
+              >
+                {label}
+              </Button>
+            </Tooltip>
+          );
+        })}
+      </Box>
     </Paper>
   );
 }


### PR DESCRIPTION
This PR improves the top-level editor UX by making the header feel more intentional and the side-panel modes easier to understand at a glance.

Changes:

- Replace the plain SwimDSL text chip with app header
- Restyle the app bar to give the header a stronger visual identity
- Make the File control read more clearly as a menu button with icon, hover, and open-state feedback
- Close the file menu when an action is selected for smoother interaction
- Redesign the right-panel switcher from icon-only disabled buttons to labeled controls with active-state styling
- Add a compact current-state summary for the right panel so users can immediately see what is open

Result:

- The header feels more polished and easier to scan
- The File entry point is more obviously interactive
- The render/tutorial/XML/hidden states are much easier to distinguish